### PR TITLE
Fix returning of resource path

### DIFF
--- a/src/utils/path.cpp
+++ b/src/utils/path.cpp
@@ -97,11 +97,10 @@ namespace Utils {
                     std::string data_dir = data_dir_list.substr(0, next_delimiter);
                     if(!data_dir.empty() && _isFolder(data_dir + "/OpMon")){
 		      return data_dir + "/OpMon/";
-		    }else{
-		      return "/usr/local/share/OpMon/";
 		    }
                     data_dir_list.erase(0, next_delimiter + 1);
                 }
+		        return "/usr/local/share/OpMon/";
             }
             return nullptr;
         }


### PR DESCRIPTION
We are in a while loop and plan to go through all elements of
XDG_DATA_DIRS. So far we actually returned out of it if only the first
path is not containig the OpMon dir, not even checking the other
elements.

Only return the default /usr/local/share/OpMon path if none of the
elements in XDG_DATA_DIRS contain OpMon.

Fixes https://github.com/OpMonTeam/OpMon/issues/52