### PR TITLE
Remove xdg-open header from desktop file

### DIFF
--- a/data/OPMon.desktop
+++ b/data/OPMon.desktop
@@ -1,4 +1,3 @@
-#!/usr/bin/env xdg-open
 [Desktop Entry]
 Encoding=UTF-8
 Name=OPMon


### PR DESCRIPTION
Actually .desktop files should not contain a header.