### PR TITLE
Replace /bin/bash by /usr/bin/env

### DIFF
--- a/scripts/format-code.sh
+++ b/scripts/format-code.sh
@@ -1,2 +1,2 @@
-#!/bin/bash
+#!/usr/bin/env bash
 find src -type f -name '*.[ch]pp' -exec clang-format -style=file  -i {} \;


### PR DESCRIPTION
Some systems have bash at different locations.
env will launch bash from that location.