### PR TITLE
Create helper function for code written twice

### DIFF
--- a/src/utils/path.cpp
+++ b/src/utils/path.cpp
@@ -16,53 +16,37 @@ namespace Utils {
             return (!stat(path.c_str(), &st) && S_ISDIR(st.st_mode));
         }
 
+        static std::string _getConfigFilesPatch(const std::string &section) {
+            const char *xdg_config_home = std::getenv("XDG_CONFIG_HOME");
+            std::string config_dir = xdg_config_home ? xdg_config_home : "";
+
+            if(config_dir.empty()) {
+                const char *home = std::getenv("HOME");
+                if(home && home[0] != '\n') {
+                    config_dir = home;
+                    config_dir += "/.config";
+                }
+            }
+            if(!config_dir.empty()) {
+                Fs::mkdir(config_dir + "/OpMon");
+                Fs::mkdir(config_dir + "/OpMon/" + section);
+                return config_dir + "/OpMon/" + section + "/";
+            }
+            return nullptr;
+        }
+
         const std::string getSavePath() {
 #ifdef _WIN32
             return "./saves";
 #endif
-            { // search in $XDG_CONFIG_HOME
-                const char *xdg_config_home = std::getenv("XDG_CONFIG_HOME");
-                std::string config_dir = xdg_config_home ? xdg_config_home : "";
-
-                if(config_dir.empty()) {
-                    const char *home = std::getenv("HOME");
-                    if(home && home[0] != '\n') {
-                        config_dir = home;
-                        config_dir += "/.config";
-                    }
-                }
-                if(!config_dir.empty()) {
-                    Fs::mkdir(config_dir + "/OpMon");
-                    Fs::mkdir(config_dir + "/OpMon/saves");
-                    return config_dir + "/OpMon/saves/";
-                }
-            }
-            return nullptr;
+            return _getConfigFilesPatch("saves");
         }
 
         const std::string getLogPath() {
 #ifdef _WIN32
             return "./log";
 #endif
-
-            { // search in $XDG_CONFIG_HOME
-                const char *xdg_config_home = std::getenv("XDG_CONFIG_HOME");
-                std::string config_dir = xdg_config_home ? xdg_config_home : "";
-
-                if(config_dir.empty()) {
-                    const char *home = std::getenv("HOME");
-                    if(home && home[0] != '\n') {
-                        config_dir = home;
-                        config_dir += "/.config";
-                    }
-                }
-                if(!config_dir.empty()) {
-                    Fs::mkdir(config_dir + "/OpMon");
-                    Fs::mkdir(config_dir + "/OpMon/log");
-                    return config_dir + "/OpMon/log/";
-                }
-            }
-            return nullptr;
+            return _getConfigFilesPatch("log");
         }
 
         const std::string getResourcePath() {


### PR DESCRIPTION
Created _getConfigFilesPatch() to contain the common things from
getSavePath() and getLogPath(). The only thing those two functions
differ in is the last directory part.