### PR TITLE
Remove variadic OpString constructor and fix related code

### DIFF
--- a/src/opmon/controller/BattleCtrl.cpp
+++ b/src/opmon/controller/BattleCtrl.cpp
@@ -218,8 +218,8 @@ namespace OpMon {
         //TODO : add messages to opTurn->toPrintBefore
         bool BattleCtrl::canAttack(Model::OpMon *opmon, Model::Turn *opTurn) {
             bool canAttack = true;
-            std::vector<std::string *> opName(1);
-            opName[0] = new std::string(opmon->getNickname());
+            std::vector<sf::String *> opName(1);
+            opName[0] = new sf::String(opmon->getNickname());
             //Checks if frozen
             if(opmon->getStatus() == Model::Status::FROZEN) {
                 //The OpMon have one chance out of 5 to be able to move again.
@@ -248,7 +248,7 @@ namespace OpMon {
                     opTurn->toPrintBefore.push_back(Utils::OpString("battle.status.paralysed.attack.fail", opName));
                     canAttack = false;
                 } else {
-                    opTurn->toPrintBefore.push_back(Utils::OpString("battle.status.paralysed.attack.success.1", std::vector<std::string *>()));
+                    opTurn->toPrintBefore.push_back(Utils::OpString("battle.status.paralysed.attack.success.1", {}));
                     opTurn->toPrintBefore.push_back(Utils::OpString("battle.status.paralysed.attack.success.2", opName));
                 }
             }
@@ -267,7 +267,7 @@ namespace OpMon {
                         opTurn->confusedHurt = true;
                     } else {
                         opTurn->toPrintBefore.push_back(Utils::OpString("battle.status.confused.attack.success.1", opName));
-                        opTurn->toPrintBefore.push_back(Utils::OpString("battle.status.confused.attack.success.2", std::vector<std::string *>()));
+                        opTurn->toPrintBefore.push_back(Utils::OpString("battle.status.confused.attack.success.2", {}));
                     }
                 }
             }

--- a/src/opmon/model/objects/Attacks.cpp
+++ b/src/opmon/model/objects/Attacks.cpp
@@ -176,7 +176,7 @@ namespace OpMon {
 
             int BerceuseAfterEffect::apply(Attack & /*attack*/, OpMon &, OpMon &def, Turn &atkTurn) {
                 if(def.setStatus(Status::SLEEPING)) {
-                    atkTurn.toPrintAfter.push_back(OpString("battle.status.sleep.in", def.getNickname()));
+                    atkTurn.toPrintAfter.push_back(OpString("battle.status.sleep.in", {&def.getNickname()}));
                 } else {
                     atkTurn.attackFailed = true;
                 }
@@ -186,7 +186,7 @@ namespace OpMon {
             int BlizzardAfterEffect::apply(Attack & /*attack*/, OpMon &, OpMon &def, Turn &atkTurn) {
                 if(Utils::Misc::randU(10) == 2) {
                     if(def.setStatus(Status::FROZEN)) {
-                        atkTurn.toPrintAfter.push_back(OpString("battle.status.frozen.in", def.getNickname()));
+                        atkTurn.toPrintAfter.push_back(OpString("battle.status.frozen.in", {&def.getNickname()}));
                     }
                 }
                 return 0;
@@ -211,7 +211,7 @@ namespace OpMon {
                     atkTurn.attackFailed = true;
                 } else {
                     if(def.setStatus(Status::PARALYSED)) {
-                        atkTurn.toPrintAfter.push_back(OpString("battle.status.paralysed.in", def.getNickname()));
+                        atkTurn.toPrintAfter.push_back(OpString("battle.status.paralysed.in", {&def.getNickname()}));
                     } else {
                         atkTurn.attackFailed = true;
                     }
@@ -222,7 +222,7 @@ namespace OpMon {
             int CascadeAfterEffect::apply(Attack & /*attack*/, OpMon &atk, OpMon &def, Turn &atkTurn) {
                 if(Utils::Misc::randU(5) == 2) {
                     def.afraid = true;
-                    atkTurn.toPrintAfter.push_back(OpString("battle.status.afraid", def.getNickname()));
+                    atkTurn.toPrintAfter.push_back(OpString("battle.status.afraid", {&def.getNickname()}));
                 }
                 return 0;
             }
@@ -230,7 +230,7 @@ namespace OpMon {
             int ChocMentalAfterEffect::apply(Attack & /*attack*/, OpMon &atk, OpMon &def, Turn &atkTurn) {
                 if(Utils::Misc::randU(10) == 2) {
                     def.confused = true;
-                    atkTurn.toPrintAfter.push_back(OpString("battle.status.confused.in", def.getNickname()));
+                    atkTurn.toPrintAfter.push_back(OpString("battle.status.confused.in", {&def.getNickname()}));
                 }
                 return 0;
             }
@@ -309,7 +309,7 @@ namespace OpMon {
             int CrocDeMortAfterEffect::apply(Attack & /*attack*/, OpMon & /*atk*/, OpMon &def, Turn &atkTurn) {
                 if(Utils::Misc::randU(10) == 2) {
                     def.afraid = true;
-                    atkTurn.toPrintAfter.push_back(OpString("battle.status.afraid", def.getNickname()));
+                    atkTurn.toPrintAfter.push_back(OpString("battle.status.afraid", {&def.getNickname()}));
                 }
                 return 0;
             }

--- a/src/opmon/model/objects/OpMon.cpp
+++ b/src/opmon/model/objects/OpMon.cpp
@@ -1355,7 +1355,7 @@ namespace OpMon {
             if(!initialized) {
 
                 std::ostringstream oss;
-                oss << nickname << std::endl;
+                oss << nickname.toAnsiString() << std::endl;
                 oss << Save::intToChar(atkIV) << std::endl;
                 oss << Save::intToChar(defIV) << std::endl;
                 oss << Save::intToChar(atkSpeIV) << std::endl;

--- a/src/opmon/model/objects/OpMon.hpp
+++ b/src/opmon/model/objects/OpMon.hpp
@@ -30,7 +30,7 @@ namespace OpMon {
 
           protected:
           private:
-            std::string nickname;
+            sf::String nickname;
             int atkIV = Utils::Misc::randU(32);
             int defIV = Utils::Misc::randU(32);
             int atkSpeIV = Utils::Misc::randU(32);
@@ -210,7 +210,7 @@ namespace OpMon {
                 return HP;
             }
 
-            std::string getNickname() {
+            sf::String& getNickname() {
                 return nickname;
             }
 

--- a/src/opmon/model/storage/OverworldData.cpp
+++ b/src/opmon/model/storage/OverworldData.cpp
@@ -61,7 +61,7 @@ namespace OpMon {
 
             Map *mapFauxbourgEuvi = maps.emplace("Fauxbourg Euvi", new Map(Maps::feLayer1, Maps::feLayer2, Maps::feLayer3, 48, 48, false, "Fauxbourg", std::vector<std::string>{"windturbine", "smoke"})).first->second;
             mapFauxbourgEuvi->addEvent(new Events::TalkingEvent(alphaTab, sf::Vector2f(19, 10), {OpString("fedesc.1"), OpString("fedesc.2"), OpString("fedesc.3")}, SIDE_UP));
-            mapFauxbourgEuvi->addEvent(new Events::TalkingEvent(alphaTab, sf::Vector2f(29, 16), {OpString("ppHouse", player->getNameP()), OpString::voidStr, OpString::voidStr}, SIDE_UP));
+              mapFauxbourgEuvi->addEvent(new Events::TalkingEvent(alphaTab, sf::Vector2f(29, 16), {OpString("ppHouse", {player->getNameP()}), OpString::voidStr, OpString::voidStr}, SIDE_UP));
             mapFauxbourgEuvi->addEvent(new Events::TalkingEvent(alphaTab, sf::Vector2f(33, 16), {OpString("rivalHouse"), OpString::voidStr, OpString::voidStr}, SIDE_UP));
             mapFauxbourgEuvi->addEvent(new Events::TalkingEvent(alphaTab, sf::Vector2f(22, 28), {OpString("labo"), OpString::voidStr, OpString::voidStr}, SIDE_UP));
             mapFauxbourgEuvi->addEvent(new Events::TalkingEvent(alphaTab, sf::Vector2f(31, 28), {OpString("weirdsign.1"), OpString("weirdsign.2"), OpString::voidStr}, SIDE_UP));

--- a/src/opmon/model/sysObjects/Player.hpp
+++ b/src/opmon/model/sysObjects/Player.hpp
@@ -41,6 +41,10 @@ namespace OpMon {
             const sf::String *getNameP() const {
                 return &name;
             }
+            
+            sf::String *getNameP() {
+                return &name;
+            }
 
             void setName(sf::String const &name) {
                 this->name = name;

--- a/src/opmon/view/StartScene.cpp
+++ b/src/opmon/view/StartScene.cpp
@@ -20,7 +20,7 @@ namespace OpMon {
                 txtP0.push_back(kget(actual));
             }
             it++;
-            strName = Utils::OpString("prof.dialog.start.19", data.getPlayer().getNameP());
+            strName = Utils::OpString("prof.dialog.start.19", {data.getPlayer().getNameP()});
             txtP1.emplace_back(); // empty space replaced later by OpString 'strName'
             for(it = it; it < 27; it++) {
                 std::string actual;

--- a/src/utils/OpString.cpp
+++ b/src/utils/OpString.cpp
@@ -8,18 +8,6 @@ namespace Utils {
   */
     OpString OpString::voidStr = OpString("void");
 
-    OpString::OpString(std::string key, ...) {
-        va_list ap;
-        this->key = key;
-        va_start(ap, key);
-        int instances = StringKeys::countInstances(StringKeys::get(key), '~');
-        for(int i = 0; i < instances; i++) {
-            sf::String *current = va_arg(ap, sf::String *);
-            objects.push_back(current);
-        }
-        va_end(ap);
-    }
-
     OpString::OpString(std::string const &key, std::vector<sf::String *> obj) {
         this->key = key;
         unsigned int instances = StringKeys::countInstances(StringKeys::get(key), '~');
@@ -42,29 +30,6 @@ namespace Utils {
                 delete(object);
             }
         }
-    }
-
-    sf::String OpString::quickString(std::string const &key, ... /* Waiting std::string pointers*/) {
-        va_list ap;
-        va_start(ap, key);
-        int instances = StringKeys::countInstances(StringKeys::get(key), '~');
-        std::vector<sf::String *> vect;
-        for(int i = 0; i < instances; i++) {
-            std::string *ptr = va_arg(ap, std::string *);
-            if(ptr != NULL && ptr != nullptr) {
-                vect.push_back(new sf::String(*ptr));
-                delete(ptr);
-            }
-        }
-        va_end(ap);
-        OpString op = OpString(key, vect);
-        sf::String str = op.getString();
-
-        for(sf::String *sfstr : vect) {
-            delete(sfstr);
-        }
-
-        return str;
     }
 
     sf::String OpString::quickString(std::string const &key, std::vector<std::string> vstr) {

--- a/src/utils/OpString.hpp
+++ b/src/utils/OpString.hpp
@@ -23,8 +23,7 @@ namespace Utils {
 
       public:
         /* Waits sf::String pointers to update the string with the pointed variable's value at each getString() call.*/
-        OpString(std::string key, ... /*Waiting sf::String pointer*/);
-        OpString(std::string const &key, std::vector<sf::String *> obj);
+        OpString(std::string const &key, std::vector<sf::String *> obj = {});
         OpString();
         ~OpString();
 
@@ -39,7 +38,6 @@ namespace Utils {
         static OpString voidStr;
 
         /** Create an OpString and returns the result of getString. Quick version to have a string because it uses std::string instead of sf::String pointers. */
-        static sf::String quickString(std::string const &key, ... /* Waiting std::string pointers*/);
         static sf::String quickString(std::string const &key, std::vector<std::string> vstr);
     };
 


### PR DESCRIPTION
This removes the variadic constructor which was breaking the build for me on macOS. Also fixes the relevant code.

As discussed on Discord, I've also modified `OpMon::getNickname()` to return an sf::String instead of std::string