### PR TITLE
Debian packager will fail on macOS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -121,7 +121,11 @@ endif()
 
 
 # CPack packaging
-set(CPACK_GENERATOR TGZ DEB) # list of packages type generated
+if (APPLE)
+    set(CPACK_GENERATOR TGZ)
+else()
+    set(CPACK_GENERATOR TGZ DEB)
+endif()
 
 #CPACK_PACKAGE_NAME
 #CPACK_PACKAGE_VENDOR


### PR DESCRIPTION
Fixed an issue with the cmake packaging which I hadn't noticed before - on Apple the Debian package won't build, so just use TGZ