### PR TITLE
Added Cocoa framework to macOS executable bundle

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -86,6 +86,9 @@ endif()
 
 # Note: the executable must be declared before adding libraries
 if (APPLE)
+    # Need Cocoa framework for Obj-C code
+    find_library(COCOA_LIBRARY Cocoa)
+
     # On Apple, Create an app bundle, which includes all the game resources and dependencies
     set_source_files_properties( ${CMAKE_SOURCE_DIR}/Resources/Other/opmon_icon.icns PROPERTIES MACOSX_PACKAGE_LOCATION Resources )
     set_source_files_properties( ${CMAKE_SOURCE_DIR}/data PROPERTIES MACOSX_PACKAGE_LOCATION Resources )
@@ -95,6 +98,9 @@ if (APPLE)
     add_executable(${EXECUTABLE_NAME} MACOSX_BUNDLE ${SOURCE_FILES}
     ${CMAKE_SOURCE_DIR}/Resources/Other/opmon_icon.icns
     ${CMAKE_SOURCE_DIR}/data)
+
+    # Add Cocoa framework to executable bundle
+    target_link_libraries(${EXECUTABLE_NAME} ${COCOA_LIBRARY})
 
     # Set the icon
     set_target_properties( ${EXECUTABLE_NAME} PROPERTIES MACOSX_BUNDLE_ICON_FILE opmon_icon.icns )


### PR DESCRIPTION
Objective-C code needs Cocoa framework to link successfully. Else, this error will come:


```
Undefined symbols for architecture x86_64:
  "_OBJC_CLASS_$_NSAutoreleasePool", referenced from:
      objc-class-ref in ResourcePath.mm.o
  "_OBJC_CLASS_$_NSBundle", referenced from:
      objc-class-ref in ResourcePath.mm.o
  "_objc_msgSend", referenced from:
      resourcePath() in ResourcePath.mm.o
ld: symbol(s) not found for architecture x86_64
```

Tested with XCode 10.1. Even if it worked fine with previous versions, this change won't hurt them.