### PR TITLE
Fixes #102

### DIFF
--- a/src/opmon/start/Gameloop.cpp
+++ b/src/opmon/start/Gameloop.cpp
@@ -67,6 +67,7 @@ namespace OpMon {
                 bool isEvent = window->getWindow().pollEvent(event);
                 if(isEvent == false)
                     event.type = sf::Event::SensorChanged;
+                _checkWindowResize(event, *window);
                 status = _checkQuit(event);
                 if(status == GameStatus::STOP)
                     break;
@@ -126,6 +127,12 @@ namespace OpMon {
         }
 
         return GameStatus::CONTINUE;
+    }
+
+    void GameLoop::_checkWindowResize(const sf::Event &event, View::Window &window) const {
+        if(event.type == sf::Event::Resized) {
+            window.updateView();
+        }
     }
 
 } // namespace OpMon

--- a/src/opmon/start/Gameloop.hpp
+++ b/src/opmon/start/Gameloop.hpp
@@ -30,6 +30,13 @@ namespace OpMon {
          */
         GameStatus _checkQuit(const sf::Event &event);
 
+        /**
+         * Checks the event for window resize, and updates the window view if it's the case.
+         * @param event The native SFMl event
+         * @param window A reference to the window in case an update is necessary
+         */
+        void _checkWindowResize(const sf::Event &event, View::Window &window) const;
+
         std::unique_ptr<Model::UiData> uidata;
         std::stack<std::unique_ptr<Controller::AGameScreen>> _gameScreens;
 

--- a/src/opmon/view/Window.hpp
+++ b/src/opmon/view/Window.hpp
@@ -9,6 +9,7 @@ File under GNU GPL v3.0 license
 
 #include <SFML/Graphics/RenderTexture.hpp>
 #include <SFML/Graphics/RenderWindow.hpp>
+#include <SFML/Graphics/Sprite.hpp>
 
 namespace OpMon {
     namespace View {
@@ -16,6 +17,7 @@ namespace OpMon {
           private:
             sf::RenderWindow window;
             sf::RenderTexture frame;
+            sf::Sprite sprite;
             bool fullScreen = false;
 
           public:
@@ -25,6 +27,7 @@ namespace OpMon {
             void open();
             void refresh();
             void reboot();
+            void updateView();
         };
     } // namespace View
 } // namespace OpMon

--- a/src/utils/centerOrigin.hpp
+++ b/src/utils/centerOrigin.hpp
@@ -1,0 +1,20 @@
+#pragma once
+
+#include <SFML/Graphics/Rect.hpp>
+#include <cmath>
+
+namespace Utils::Origin {
+    /**
+     * Template function for centering graphical objects' origins.
+     *
+     * It has to be a template function, because we need setOrigin() from Transformable and getLocalBounds() from
+     * the Drawable implementations.
+     * @tparam T The type of the graphical object in argument
+     * @param transformable The graphical object that will have its origin centered
+     */
+    template <class T>
+    void centerOrigin(T& transformable) {
+        sf::FloatRect bounds = transformable.getLocalBounds();
+        transformable.setOrigin(std::floor(bounds.left + bounds.width / 2.f), std::floor(bounds.top + bounds.height / 2.f));
+    }
+}


### PR DESCRIPTION
Uses letterboxing : the view is scaled so that the whole content of the frame, and only the content of the frame, is always shown ; the excess background is kept black. It works fine when toggling fullscreen on and off.