### PR TITLE
Properly ignore VSCode files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,8 +72,8 @@ GTAGS
 doc/html
 # Visual Studio Code
 .vscode/*
-!.vscode/settings.json
-!.vscode/tasks.json
-!.vscode/launch.json
-!.vscode/extensions.json
+.vscode/settings.json
+.vscode/tasks.json
+.vscode/launch.json
+.vscode/extensions.json
 *.code-workspace


### PR DESCRIPTION
The `!` means that the file is NOT ignored by the `.gitignore`.

But we do want to ignore those files when working with VSCode.