### PR TITLE
Refactor Dialog class to inherit from sf::Drawable

### DIFF
--- a/src/opmon/view/Battle.cpp
+++ b/src/opmon/view/Battle.cpp
@@ -218,7 +218,7 @@ namespace OpMon {
                 if(dialog == nullptr) { //Always show the dialog box (if possible)
                     dialog = new Dialog(" ", data.getUiDataPtr());
                 }
-                dialog->draw(frame);
+                frame.draw(*dialog);
 
             } else if(!attackChoice) { // Main battle menu
 

--- a/src/opmon/view/Dialog.cpp
+++ b/src/opmon/view/Dialog.cpp
@@ -119,25 +119,26 @@ namespace OpMon {
                     }
                 }
             }
+            for(size_t itor = 0; itor < 3; itor++) {
+                dialogText[itor].setString(currentTxt[itor].toUtf32());
+            }
+            sf::Vector2f posArrow(512 - 40, 512 - 40);
+            arrDial.move(0, 0.33f);
+            if(arrDial.getPosition().y - posArrow.y > 5) {
+                arrDial.move(0, -6);
+            }
         }
 
-        void Dialog::draw(sf::RenderTarget &frame) {
+        void Dialog::draw(sf::RenderTarget &target, sf::RenderStates states) const {
             if(backgroundVisible) {
-                frame.draw(background);
+                target.draw(background);
                 {
-
                     for(size_t itor = 0; itor < 3; itor++) {
-                        dialogText[itor].setString(currentTxt[itor].toUtf32());
-                        frame.draw(dialogText[itor]);
+                        target.draw(dialogText[itor]);
                     }
 
-                    sf::Vector2f posArrow(512 - 40, 512 - 40);
-                    arrDial.move(0, 0.33f);
-                    if(arrDial.getPosition().y - posArrow.y > 5) {
-                        arrDial.move(0, -6);
-                    }
                     if(text.size() > 0 && changeDialog)
-                        frame.draw(arrDial);
+                        target.draw(arrDial);
                 }
             }
         }

--- a/src/opmon/view/Dialog.hpp
+++ b/src/opmon/view/Dialog.hpp
@@ -17,7 +17,7 @@
 namespace OpMon {
     namespace View {
 
-        class Dialog {
+        class Dialog : public sf::Drawable {
           private:
             /*!
              * \brief Array of all lines composing the dialog.
@@ -102,7 +102,7 @@ namespace OpMon {
             /*!
              * \brief Draw the dialog on the main frame.
              */
-            void draw(sf::RenderTarget &frame);
+            virtual void draw(sf::RenderTarget &target, sf::RenderStates states) const;
 
             /*!
              * \return `true` is the entire dialog has been displayed; `false` otherwise.

--- a/src/opmon/view/Overworld.cpp
+++ b/src/opmon/view/Overworld.cpp
@@ -313,7 +313,7 @@ namespace OpMon {
             frame.setView(frame.getDefaultView());
 
             if(is_in_dialog) {
-                this->dialog->draw(frame);
+                frame.draw(*this->dialog);
             }
 
             if(debugMode) {

--- a/src/opmon/view/StartScene.cpp
+++ b/src/opmon/view/StartScene.cpp
@@ -107,7 +107,7 @@ namespace OpMon {
             case 2:
                 frame.draw(bg);
                 frame.draw(prof);
-                dialog->draw(frame);
+                frame.draw(*dialog);
                 break;
             case 1:
                 frame.draw(bgName);


### PR DESCRIPTION
This PR makes the `Dialog`class inherit from the `sf::Drawable` class. This makes more sense and allow us to use the `frame.draw(dialog)` syntax, which is more consistent.

The `draw()` method being `const`, I had to move some things out of it.