### PR TITLE
New look for dialogues

### DIFF
--- a/data/keys/english.rkeys
+++ b/data/keys/english.rkeys
@@ -39,7 +39,7 @@ key.nameEntry.med=Enter a name
 key.nameEntry.indic.1=Press Return key when
 key.nameEntry.indic.2=you have finished
 
-key.prof.dialog.start.1=Hello and welcome to Regimys ! I hope you are fine! I am the professor Kiwaï, owner of the OpMon laboratory of Euvi-town.You are maybe wondering yourself : "What is he doing in this little town?" Here is my story.$This is where I grew up and met my first OpMon : Furnursus. It is a little fire animal cute and protective. I refused to make him evolve so he stays cute!$Sorry, I am only talking about me. So... What is your name?
+key.prof.dialog.start.1=Hello and welcome to Regimys! I hope you are fine! I am the professor Kiwaï, owner of the OpMon laboratory of Euvi-town.You are maybe wondering yourself : "What is he doing in this little town?" Here is my story.$This is where I grew up and met my first OpMon : Furnursus. It is a little fire animal cute and protective. I refused to make him evolve so he stays cute!$Sorry, I am only talking about me. So... What is your name?
 key.prof.dialog.start.2=Well, ~, I will tell you about this place and the creatures living in here. Are you ready?$This look of you...$You seem familiar with this place. Have you already been here?|Well, I suppose I will let you discover it by yourself.|See you soon!
 
 key.fedesc.1=Euvi Town|This little town is calm and relaxing.

--- a/src/opmon/model/storage/MainMenuData.cpp
+++ b/src/opmon/model/storage/MainMenuData.cpp
@@ -10,7 +10,6 @@ namespace OpMon {
     namespace Model {
         MainMenuData::MainMenuData(UiData *ptr)
           : uidata(ptr) {
-            ResourceLoader::load(menuframe, "backgrounds/menuframe.png");
             ResourceLoader::load(arrChoice, "sprites/misc/arrChoiceScale.png");
         }
     } // namespace Model

--- a/src/opmon/model/storage/MainMenuData.hpp
+++ b/src/opmon/model/storage/MainMenuData.hpp
@@ -15,7 +15,6 @@ namespace OpMon {
          */
         class MainMenuData {
           private:
-            sf::Texture menuframe;
             sf::Texture arrChoice;
 
             UiData *uidata;
@@ -31,7 +30,6 @@ namespace OpMon {
              */
             UiData *getUiDataPtr() const { return uidata; }
           
-            sf::Texture const &getMenuframe() const { return menuframe; }
             /*!
              * \brief Gets the cursor.
              */

--- a/src/opmon/model/storage/OptionsMenuData.cpp
+++ b/src/opmon/model/storage/OptionsMenuData.cpp
@@ -17,7 +17,6 @@ namespace OpMon {
             ResourceLoader::load(controlsBg, "backgrounds/controls.png");
             ResourceLoader::load(volumeCur, "sprites/misc/cursor.png");
             ResourceLoader::load(keyChange, "sprites/misc/keyChange.png");
-            ResourceLoader::load(menuframe, "backgrounds/menuframe.png");
         }
     } // namespace Model
 } // namespace OpMon

--- a/src/opmon/model/storage/OptionsMenuData.hpp
+++ b/src/opmon/model/storage/OptionsMenuData.hpp
@@ -23,7 +23,6 @@ namespace OpMon {
             sf::Texture controlsBg;
             sf::Texture volumeCur;
             sf::Texture keyChange;
-            sf::Texture menuframe;
 
             /*!
              * \brief The copy constructor. Not defined, must not be used.
@@ -59,7 +58,6 @@ namespace OpMon {
              * \brief Gets the texture of the cursor used in the controls.
              */
             sf::Texture const &getKeyChange() const { return keyChange; }
-            sf::Texture const &getMenuframe() const { return menuframe; }
             /*!
              * \brief Gets a pointer to the UiData object.
              */

--- a/src/opmon/model/storage/UiData.cpp
+++ b/src/opmon/model/storage/UiData.cpp
@@ -20,6 +20,8 @@ namespace OpMon {
 
             Utils::Log::oplog("Initializating UiData");
 
+            ResourceLoader::load(menuFrame, "backgrounds/menuframe.png");
+
             jukebox.addMusic("Title", "audio/music/title.ogg", 50);
             jukebox.addMusic("Start", "audio/music/intro.ogg");
             jukebox.addMusic("Fauxbourg", "audio/music/faubourgeuvi.ogg");

--- a/src/opmon/model/storage/UiData.hpp
+++ b/src/opmon/model/storage/UiData.hpp
@@ -46,6 +46,11 @@ namespace OpMon {
             sf::Keyboard::Key interact;
             sf::Keyboard::Key talk;
 
+            uint32_t windowHeight = 512;
+            uint32_t windowWidth = 512;
+
+            sf::Texture menuFrame;
+
             /*!
              * \brief The copy constructor. Not defined, must not be used.
              */
@@ -110,6 +115,18 @@ namespace OpMon {
              * \brief Gets the key for the "talk" action.
              */
             sf::Keyboard::Key getKeyTalk() const { return talk; }
+
+            /*!
+             * \brief Gets the heigth of the window
+             */
+            uint32_t getWindowHeight() const { return windowHeight; }
+
+            /*!
+             * \brief Gets the width of the window
+             */
+            uint32_t getWindowWidth() const { return windowWidth; }
+
+            sf::Texture &getMenuFrame() { return menuFrame; }
 
             /*!
              * \brief Sets the key for the "up" action.

--- a/src/opmon/view/Dialog.hpp
+++ b/src/opmon/view/Dialog.hpp
@@ -4,13 +4,14 @@
  * \authors Cyrielle
  * \copyright GNU GPL 3.0
 */
-#ifndef OPMON_DIALOG_CPP_HPP
-#define OPMON_DIALOG_CPP_HPP
+
+#pragma once
 
 #include "../model/storage/UiData.hpp"
 #include <SFML/Audio.hpp>
 #include <SFML/Graphics.hpp>
 #include <SFML/System.hpp>
+#include "ui/TextBox.hpp"
 #include <queue>
 #include <string>
 
@@ -19,6 +20,18 @@ namespace OpMon {
 
         class Dialog : public sf::Drawable {
           private:
+            TextBox *dialogBox;
+
+            /*!
+             * \brief Height of a dialog box.
+             */
+            uint32_t dialogBoxHeight;
+
+            /*!
+             * \brief Width of a dialog box.
+             */
+            uint32_t dialogBoxWidth;
+
             /*!
              * \brief Array of all lines composing the dialog.
              */
@@ -39,16 +52,17 @@ namespace OpMon {
             /*!
              * \brief Number of completely displayed lines.
              */
-            unsigned int line = 0;
+            uint32_t line = 0;
+
             /*!
              * \brief Index of the next character to display by the text animation.
              */
-            unsigned int i = 0;
+            uint32_t i = 0;
 
             /*!
              * \brief Set to `true` when the entire dialog has been displayed.
              */
-            bool is_dialog_over = false;
+            bool dialogOver = false;
 
             /*!
              * \brief The sound played when a dialog is passed.
@@ -57,21 +71,11 @@ namespace OpMon {
 
             Model::UiData *uidata;
 
-            bool backgroundVisible = true;
+            sf::Sprite arrDial;
 
             void init();
 
-            sf::Sprite arrDial;
-            sf::Text dialogText[3];
-            sf::Sprite background;
-
           public:
-            /*!
-             * \brief Initialises a dialog with an array of texts to print.
-             * \param text An array of texts. One element = one line.
-             * \deprecated Use std::queue instead of std::vector, or send one sf::String directly.
-             */
-            OP_DEPRECATED Dialog(std::vector<sf::String> text, Model::UiData *uidata);
             /*!
              * \brief Initises a dialog with a queue of texts to print.
              * \param text A queue of texts. One element = one line.
@@ -108,12 +112,6 @@ namespace OpMon {
              * \return `true` is the entire dialog has been displayed; `false` otherwise.
              */
             bool isDialogOver();
-
-            /*!
-             * \brief Set the background visible or invisible, used in screens using other dialog boxes.
-             */
-            void setBackgroundVisible(bool visible);
         };
     } // namespace View
 } // namespace OpMon
-#endif //OPMON_DIALOG_CPP_HPP

--- a/src/opmon/view/MainMenu.cpp
+++ b/src/opmon/view/MainMenu.cpp
@@ -25,7 +25,7 @@ namespace OpMon {
 
             for(int i = 0; i < 4; i++) {
                 sf::Vector2f position(MAIN_MENU_ITEM_PADDING, MAIN_MENU_ITEM_PADDING + i * (MAIN_MENU_ITEM_HEIGHT + MAIN_MENU_ITEM_PADDING));
-                TextBox mainMenuItem(data.getMenuframe(), position, MAIN_MENU_ITEM_WIDTH, MAIN_MENU_ITEM_HEIGHT);
+                TextBox mainMenuItem(data.getUiDataPtr()->getMenuFrame(), position, MAIN_MENU_ITEM_WIDTH, MAIN_MENU_ITEM_HEIGHT);
                 mainMenuItem.setFont(data.getUiDataPtr()->getFont());
                 mainMenuItems.push_back(mainMenuItem);
             }

--- a/src/opmon/view/OptionsMenu.cpp
+++ b/src/opmon/view/OptionsMenu.cpp
@@ -103,7 +103,7 @@ namespace OpMon {
             // Create text boxes for the main screen
             for(int i = 0; i < 6; i++) {
                 sf::Vector2f position(OPTIONS_MENU_ITEM_PADDING, OPTIONS_MENU_ITEM_PADDING + i * (OPTIONS_MENU_ITEM_HEIGHT + OPTIONS_MENU_ITEM_PADDING));
-                TextBox optionsMenuItem(data.getMenuframe(), position, OPTIONS_MENU_ITEM_WIDTH, OPTIONS_MENU_ITEM_HEIGHT);
+                TextBox optionsMenuItem(data.getUiDataPtr()->getMenuFrame(), position, OPTIONS_MENU_ITEM_WIDTH, OPTIONS_MENU_ITEM_HEIGHT);
                 optionsMenuItem.setFont(data.getUiDataPtr()->getFont());
                 optionsMenuItems.push_back(optionsMenuItem);
             }
@@ -113,7 +113,7 @@ namespace OpMon {
             // Create text boxes for the language selection screen
             for(int i = 0; i < 6; i++) {
                 sf::Vector2f position(OPTIONS_MENU_ITEM_PADDING, OPTIONS_MENU_ITEM_PADDING + i * (OPTIONS_MENU_ITEM_HEIGHT + OPTIONS_MENU_ITEM_PADDING));
-                TextBox languagesMenuItem(data.getMenuframe(), position, OPTIONS_MENU_ITEM_WIDTH, OPTIONS_MENU_ITEM_HEIGHT);
+                TextBox languagesMenuItem(data.getUiDataPtr()->getMenuFrame(), position, OPTIONS_MENU_ITEM_WIDTH, OPTIONS_MENU_ITEM_HEIGHT);
                 languagesMenuItem.setFont(data.getUiDataPtr()->getFont());
                 languagesMenuItems.push_back(languagesMenuItem);
             }

--- a/src/opmon/view/ui/TextBox.cpp
+++ b/src/opmon/view/ui/TextBox.cpp
@@ -6,7 +6,7 @@
 #include <ostream>
 #include <sstream>
 
-TextBox::TextBox(sf::Texture texture, sf::Vector2f position, int width, int height, uint32_t linesCount)
+TextBox::TextBox(sf::Texture texture, sf::Vector2f position, uint32_t width, uint32_t height, uint32_t linesCount)
   : texture(texture)
   , position(position)
   , width(width)
@@ -24,16 +24,16 @@ TextBox::TextBox(sf::Texture texture, sf::Vector2f position, int width, int heig
     }
 
     // Size of one of the nine parts of the text box (assuming its a square)
-    int partSize = 16;
+    uint32_t partSize = 16;
 
-    for(unsigned int i = 0; i < 3; ++i) {
-        for(unsigned int j = 0; j < 3; ++j) {
+    for(uint32_t i = 0; i < 3; ++i) {
+        for(uint32_t j = 0; j < 3; ++j) {
             sf::Vertex *quad = &this->vertexArray[(i * 3 + j) * 4];
 
-            int currentQuadX = 0;
-            int currentQuadY = 0;
-            int currentQuadWidth = 0;
-            int currentQuadHeight = 0;
+            uint32_t currentQuadX = 0;
+            uint32_t currentQuadY = 0;
+            uint32_t currentQuadWidth = 0;
+            uint32_t currentQuadHeight = 0;
 
             if(i == 0 && j == 0) {
                 // Top-left part
@@ -147,8 +147,8 @@ void TextBox::setRightContent(const sf::String &content) {
 
 void TextBox::setActive(bool active) {
 
-    for(unsigned int i = 0; i < 3; ++i) {
-        for(unsigned int j = 0; j < 3; ++j) {
+    for(uint32_t i = 0; i < 3; ++i) {
+        for(uint32_t j = 0; j < 3; ++j) {
             sf::Vertex *quad = &this->vertexArray[(i * 3 + j) * 4];
 
             if(active) {

--- a/src/opmon/view/ui/TextBox.cpp
+++ b/src/opmon/view/ui/TextBox.cpp
@@ -6,15 +6,22 @@
 #include <ostream>
 #include <sstream>
 
-TextBox::TextBox(sf::Texture texture, sf::Vector2f position, int width, int height)
+TextBox::TextBox(sf::Texture texture, sf::Vector2f position, int width, int height, uint32_t linesCount)
   : texture(texture)
   , position(position)
   , width(width)
   , height(height) {
 
     // Some default values for the left text
-    sf::Vector2f leftTextPosition(position.x + 24, position.y + 24);
-    leftText.setPosition(leftTextPosition);
+    for (uint32_t i = 0; i < linesCount; i++) {
+        sf::Text newLeftText;
+        sf::Vector2f leftTextPosition(position.x + 24, position.y + 24 * (i+1));
+        newLeftText.setPosition(leftTextPosition);
+        leftText.push_back(newLeftText);
+
+        sf::Text newRightText;
+        rightText.push_back(newRightText);
+    }
 
     // Size of one of the nine parts of the text box (assuming its a square)
     int partSize = 16;
@@ -100,31 +107,42 @@ TextBox::TextBox(sf::Texture texture, sf::Vector2f position, int width, int heig
 void TextBox::draw(sf::RenderTarget &target, sf::RenderStates states) const {
     states.texture = &this->texture;
     target.draw(this->vertexArray, states);
-    target.draw(this->leftText, states);
-    target.draw(this->rightText, states);
+
+    for (auto& text : leftText) {
+        target.draw(text, states);
+    }
+
+    for (auto& text : rightText) {
+        target.draw(text, states);
+    }
 }
 
 void TextBox::setFont(const sf::Font &font) {
-    leftText.setFillColor(sf::Color::Black);
-    leftText.setFont(font);
-    leftText.setCharacterSize(16);
-    rightText.setFillColor(sf::Color::Black);
-    rightText.setFont(font);
-    rightText.setCharacterSize(16);
+    for (auto& text : leftText) {
+        text.setFillColor(sf::Color::Black);
+        text.setFont(font);
+        text.setCharacterSize(16);
+    }
+
+    for (auto& text : rightText) {
+        text.setFillColor(sf::Color::Black);
+        text.setFont(font);
+        text.setCharacterSize(16);
+    }
 }
 
-void TextBox::setLeftContent(const sf::String &content) {
-    leftText.setString(content);
+void TextBox::setLeftContent(const sf::String &content, uint32_t line) {
+    leftText[line].setString(content);
 }
 
 void TextBox::setRightContent(const sf::String &content) {
-    rightText.setString(content);
+    rightText[0].setString(content);
 
     // We need to recalculate the position of the right text each time we change its string
-    sf::FloatRect rightTextGlobalBound = rightText.getGlobalBounds();
+    sf::FloatRect rightTextGlobalBound = rightText[0].getGlobalBounds();
     float rightTextWidth = rightTextGlobalBound.width;
     sf::Vector2f rightTextPosition(position.x + width - rightTextWidth - 24, position.y + 24);
-    rightText.setPosition(rightTextPosition);
+    rightText[0].setPosition(rightTextPosition);
 }
 
 void TextBox::setActive(bool active) {

--- a/src/opmon/view/ui/TextBox.hpp
+++ b/src/opmon/view/ui/TextBox.hpp
@@ -20,10 +20,10 @@ class TextBox : public sf::Drawable {
     int height;
 
     // An eventual text to be displayed in the left side of the box
-    sf::Text leftText;
+    std::vector<sf::Text> leftText;
 
     // An eventual text to be displayed in the right side of the box
-    sf::Text rightText;
+    std::vector<sf::Text> rightText;
 
     // The font to display the text with
     sf::Font font;
@@ -45,7 +45,7 @@ class TextBox : public sf::Drawable {
      * \param width The width of the box.
      * \param height The height of the box.
      */
-    TextBox(sf::Texture texture, sf::Vector2f position, int width, int height);
+    TextBox(sf::Texture texture, sf::Vector2f position, int width, int height, uint32_t linesCount = 1);
 
     ~TextBox() = default;
 
@@ -59,7 +59,7 @@ class TextBox : public sf::Drawable {
      * \brief Set the string used for the content of the text in the left of the box.
      * \param content A string to use for the content.
      */
-    void setLeftContent(const sf::String& content);
+    void setLeftContent(const sf::String& content, uint32_t line = 0);
 
     /**!
      * \brief Set the string used for the content of the text in the right of the box.

--- a/src/opmon/view/ui/TextBox.hpp
+++ b/src/opmon/view/ui/TextBox.hpp
@@ -14,10 +14,10 @@ class TextBox : public sf::Drawable {
     sf::Vector2f position;
 
     // The width of the box
-    int width;
+    uint32_t width;
 
     // The height of the box
-    int height;
+    uint32_t height;
 
     // An eventual text to be displayed in the left side of the box
     std::vector<sf::Text> leftText;
@@ -28,6 +28,7 @@ class TextBox : public sf::Drawable {
     // The font to display the text with
     sf::Font font;
 
+    // Whether or not the box is active (i.e. if it's greyed out or not)
     bool active;
 
     sf::Color activeColor = sf::Color(255, 255, 255, 255);
@@ -44,8 +45,9 @@ class TextBox : public sf::Drawable {
      * \param position The position fo the box.
      * \param width The width of the box.
      * \param height The height of the box.
+     * \param linesCount The number of lines of text to display in the box.
      */
-    TextBox(sf::Texture texture, sf::Vector2f position, int width, int height, uint32_t linesCount = 1);
+    TextBox(sf::Texture texture, sf::Vector2f position, uint32_t width, uint32_t height, uint32_t linesCount = 1);
 
     ~TextBox() = default;
 
@@ -58,6 +60,7 @@ class TextBox : public sf::Drawable {
     /**!
      * \brief Set the string used for the content of the text in the left of the box.
      * \param content A string to use for the content.
+     * \param line The index of the line for which the content will be set (start at 0).
      */
     void setLeftContent(const sf::String& content, uint32_t line = 0);
 

--- a/src/utils/defines.hpp
+++ b/src/utils/defines.hpp
@@ -42,7 +42,7 @@
 /*!
  * \brief Contains the default size font.
  */
-#define FONT_SIZE_DEFAULT 25
+#define FONT_SIZE_DEFAULT 16
 
 /*!
  * \brief Contains the number PI with 11 digits.


### PR DESCRIPTION
This MR uses the same `TextBox` class that was used for the main menu items for the dialog boxes. In order to do this, I added a feature to the `TextBox` class to display several lines instead of only one.

Please do not merge this PR immediatly, I want to squash some commits before merging.