### PR TITLE
Create a load menu by specifying the context of the save menu

### DIFF
--- a/src/opmon/screens/gamemenu/GameMenuCtrl.cpp
+++ b/src/opmon/screens/gamemenu/GameMenuCtrl.cpp
@@ -88,7 +88,7 @@ namespace OpMon {
         void GameMenuCtrl::loadNextScreen() {
             switch(submenuToLoadNext) {
             case SubMenu::SAVE_MENU:
-                _next_gs = std::make_unique<SaveMenuCtrl>(data.getGameDataPtr());
+                _next_gs = std::make_unique<SaveMenuCtrl>(data.getGameDataPtr(), SaveMenuContext::SAVING);
                 break;
             case SubMenu::SETTINGS_MENU:
                 _next_gs = std::make_unique<OptionsMenuCtrl>(data.getGameDataPtr());

--- a/src/opmon/screens/mainmenu/MainMenu.hpp
+++ b/src/opmon/screens/mainmenu/MainMenu.hpp
@@ -17,6 +17,14 @@ class RenderTarget;
 }  // namespace sf
 
 namespace OpMon {
+
+/*!
+ * \brief Represent one of the option that can be accessed from the main menu.
+ */
+enum MainMenuOption { START_GAME,
+                      GO_TO_LOAD_MENU,
+                      GO_TO_SETTINGS_MENU };
+
 class MainMenuData;
 
     /*!

--- a/src/opmon/screens/mainmenu/MainMenuCtrl.cpp
+++ b/src/opmon/screens/mainmenu/MainMenuCtrl.cpp
@@ -11,24 +11,22 @@
 #include <SFML/Window/Keyboard.hpp>
 #include <memory>
 
-#include "src/opmon/screens/optionsmenu/OptionsMenuCtrl.hpp"
-#include "src/opmon/screens/introscene/IntroSceneCtrl.hpp"
-#include "src/opmon/core/GameData.hpp"
 #include "MainMenu.hpp"
 #include "MainMenuData.hpp"
+#include "src/opmon/core/GameData.hpp"
 #include "src/opmon/screens/base/AGameScreen.hpp"
+#include "src/opmon/screens/introscene/IntroSceneCtrl.hpp"
+#include "src/opmon/screens/optionsmenu/OptionsMenuCtrl.hpp"
+#include "src/opmon/screens/savemenu/SaveMenu.hpp"
+#include "src/opmon/screens/savemenu/SaveMenuCtrl.hpp"
 #include "src/opmon/view/ui/Jukebox.hpp"
 #include "src/utils/CycleCounter.hpp"
-
-//Defines created to make the code easier to read
-#define LOAD_STARTSCENE 1
-#define LOAD_OPTIONS 2
 
 namespace OpMon {
 
     MainMenuCtrl::MainMenuCtrl(GameData *data)
-        : data(data)
-        , view(this->data) {
+      : data(data)
+      , view(this->data) {
     }
 
     GameStatus MainMenuCtrl::checkEvent(sf::Event const &event) {
@@ -38,14 +36,15 @@ namespace OpMon {
             case sf::Keyboard::Return:
                 switch(curPosI.getValue()) {
                 case 0:
-                    loadNext = LOAD_STARTSCENE;
+                    selectedOption = MainMenuOption::START_GAME;
                     data.getGameDataPtr()->getJukebox().playSound("push");
                     return GameStatus::NEXT;
                 case 1:
-                    data.getGameDataPtr()->getJukebox().playSound("nope");
-                    return GameStatus::CONTINUE;
+                    selectedOption = MainMenuOption::GO_TO_LOAD_MENU;
+                    data.getGameDataPtr()->getJukebox().playSound("push");
+                    return GameStatus::NEXT_NLS;
                 case 2:
-                    loadNext = LOAD_OPTIONS;
+                    selectedOption = MainMenuOption::GO_TO_SETTINGS_MENU;
                     data.getGameDataPtr()->getJukebox().playSound("push");
                     return GameStatus::NEXT_NLS;
                 case 3:
@@ -76,15 +75,18 @@ namespace OpMon {
     }
 
     void MainMenuCtrl::loadNextScreen() {
-        switch(loadNext) {
-        case LOAD_STARTSCENE:
+        switch(selectedOption) {
+        case MainMenuOption::START_GAME:
             _next_gs = std::make_unique<IntroSceneCtrl>(data.getGameDataPtr());
             break;
-        case LOAD_OPTIONS:
+        case MainMenuOption::GO_TO_LOAD_MENU:
+            _next_gs = std::make_unique<SaveMenuCtrl>(data.getGameDataPtr(), SaveMenuContext::LOADING);
+            break;
+        case MainMenuOption::GO_TO_SETTINGS_MENU:
             _next_gs = std::make_unique<OptionsMenuCtrl>(data.getGameDataPtr());
             break;
         default:
-            throw Utils::UnexpectedValueException(std::to_string(loadNext), "a view to load in MainMenuCtrl::loadNextScreen()");
+            throw Utils::UnexpectedValueException(std::to_string(selectedOption), "a view to load in MainMenuCtrl::selectedOptionScreen()");
         }
     }
 

--- a/src/opmon/screens/mainmenu/MainMenuCtrl.hpp
+++ b/src/opmon/screens/mainmenu/MainMenuCtrl.hpp
@@ -31,7 +31,7 @@ class GameData;
          *
          * This integer is filled with some special values determined by macros in GameMenuCtrl.cpp. Currently, there is LOAD_STARTSCENE and LOAD_OPTIONS. Then, loadNextScreen loads in _next_gs a game screen according the value of this variable().
          */
-        int loadNext = 0;
+        MainMenuOption selectedOption = MainMenuOption::START_GAME;
         /*!
          * \brief The position of the cursor on the menu.
          */

--- a/src/opmon/screens/savemenu/SaveMenu.cpp
+++ b/src/opmon/screens/savemenu/SaveMenu.cpp
@@ -9,14 +9,19 @@ namespace OpMon {
     int SAVE_MENU_ITEM_WIDTH = 504;
     int SAVE_MENU_ITEM_PADDING = 4;
 
-    SaveMenu::SaveMenu(SaveMenuData &data)
+    SaveMenu::SaveMenu(SaveMenuData &data, SaveMenuContext context)
       : data(data) {
         float saveMenuItemX = (data.getGameDataPtr()->getWindowWidth() - SAVE_MENU_ITEM_WIDTH) / 2;
 
         sf::Vector2f hintTextBoxPosition(saveMenuItemX, SAVE_MENU_ITEM_PADDING);
         hintTextBox = TextBox(data.getGameDataPtr()->getMenuFrame(), hintTextBoxPosition, SAVE_MENU_ITEM_WIDTH, 64);
         hintTextBox.setFont(data.getGameDataPtr()->getFont());
-        hintTextBox.setLeftContent("Select a file to save to:");
+
+        if (context == SaveMenuContext::SAVING) {
+            hintTextBox.setLeftContent("Select a file to save to:");
+        } else if (context == SaveMenuContext::LOADING) {
+            hintTextBox.setLeftContent("Select a file to load:");
+        }
 
         for(int i = 0; i < 3; i++) {
             sf::Vector2f position(saveMenuItemX, 64 + (2 * SAVE_MENU_ITEM_PADDING) + i * (96 + SAVE_MENU_ITEM_PADDING));

--- a/src/opmon/screens/savemenu/SaveMenu.hpp
+++ b/src/opmon/screens/savemenu/SaveMenu.hpp
@@ -9,6 +9,13 @@
 namespace OpMon {
 
     /*!
+     * \brief Context in which the save menu was opened, i.e. is the player
+     * trying to save or load.
+     */
+    enum class SaveMenuContext { SAVING,
+                                 LOADING };
+
+    /*!
      * \brief State of the save menu, i.e. whether the player is currently
      * selecting a file or confirming the selected file.
      */
@@ -23,7 +30,7 @@ namespace OpMon {
 
     class SaveMenu : public Utils::I18n::ATranslatable, public sf::Drawable {
       public:
-        SaveMenu(SaveMenuData &data);
+        SaveMenu(SaveMenuData &data, SaveMenuContext context);
 
         ~SaveMenu() = default;
 

--- a/src/opmon/screens/savemenu/SaveMenuCtrl.cpp
+++ b/src/opmon/screens/savemenu/SaveMenuCtrl.cpp
@@ -1,10 +1,12 @@
 #include "SaveMenuCtrl.hpp"
 
+#include "SaveMenu.hpp"
+
 namespace OpMon {
 
-    SaveMenuCtrl::SaveMenuCtrl(GameData *data)
+    SaveMenuCtrl::SaveMenuCtrl(GameData *data, SaveMenuContext context)
       : data(data)
-      , view(this->data) {
+      , view(this->data, context) {
     }
 
     GameStatus SaveMenuCtrl::checkEvent(sf::Event const &event) {

--- a/src/opmon/screens/savemenu/SaveMenuCtrl.hpp
+++ b/src/opmon/screens/savemenu/SaveMenuCtrl.hpp
@@ -14,7 +14,7 @@ namespace OpMon {
 
     class SaveMenuCtrl : public AGameScreen {
       public:
-        SaveMenuCtrl(GameData *data);
+        SaveMenuCtrl(GameData *data, SaveMenuContext context);
 
         GameStatus checkEvent(sf::Event const &event) override;
 


### PR DESCRIPTION
This PR creates a `SaveMenuContext` enum that allow us to specifiy if we want to open the save menu to save or load the game.

If we open the save menu from the in-game menu, the context is `SAVING`.

If we open the save menu from the main menu, the context is `LOADING`.